### PR TITLE
Add versions to formulae

### DIFF
--- a/Formula/libinotify-kqueue.rb
+++ b/Formula/libinotify-kqueue.rb
@@ -3,6 +3,7 @@ class LibinotifyKqueue < Formula
   homepage "https://github.com/libinotify-kqueue/libinotify-kqueue"
   url "https://github.com/libinotify-kqueue/libinotify-kqueue.git",
     :revision => "a822c8f1d75404fe3132f695a898dcd42fe8afbc"
+  version "a822c8f1d75404fe3132f695a898dcd42fe8afbc"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/libsecp256k1.rb
+++ b/Formula/libsecp256k1.rb
@@ -3,6 +3,7 @@ class Libsecp256k1 < Formula
   homepage "https://github.com/bitcoin/secp256k1"
   url "https://github.com/bitcoin/secp256k1.git",
     :revision => "1e6f1f5ad5e7f1e3ef79313ec02023902bf8175c"
+  version "1e6f1f5ad5e7f1e3ef79313ec02023902bf8175c"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build


### PR DESCRIPTION
Per new homebrew requirements (see e.g. https://github.com/riscv/homebrew-riscv/pull/32).

<img width="622" alt="Screen Shot 2020-11-03 at 12 43 19 AM" src="https://user-images.githubusercontent.com/73197/97953706-52a43280-1d6f-11eb-9387-3f02cbc60159.png">
